### PR TITLE
Refactor to Be Context Agnostic

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const btoa = require('btoa');
 
 Toolkit.run(async tools => {
   console.log(tools.context);
-  console.log(`REPO: ${tools.context.repo}`);
+  console.log(`REPO: ${JSON.stringify(tools.context.repo)}`);
   // Assign owner and repo data to variables
   const owner = tools.context.repo.owner.login;
   const repo = tools.context.repo.name;

--- a/index.js
+++ b/index.js
@@ -8,9 +8,9 @@ Toolkit.run(async tools => {
   console.log(tools.context);
   console.log(`REPO: ${JSON.stringify(tools.context.repo)}`);
   // Assign owner and repo data to variables
-  const owner = tools.context.repo.owner.login;
-  const repo = tools.context.repo.name;
-  const repoSHA = tools.context.repo.sha;
+  const owner = tools.context.repo.owner;
+  const repo = tools.context.repo.repo;
+  // const repoSHA = tools.context.repo.sha;
 
   // Get Latest DEV Posts
 
@@ -122,6 +122,8 @@ Toolkit.run(async tools => {
       owner,
       repo
     })).data;
+
+    console.log(`REFSDATA: ${JSON.stringify(refsData)}`);
 
     // If branch does not exist, create branch
     if (refsData.filter(data => (data.ref == 'refs/heads/dev_to_jekyll')).length == 0) {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,8 @@ const axios = require('axios').default;
 const btoa = require('btoa');
 
 Toolkit.run(async tools => {
-  console.log(tools.context)
+  console.log(tools.context);
+  console.log(`REPO: ${tools.context.repo}`);
   // Assign owner and repo data to variables
   const owner = tools.context.repo.owner.login;
   const repo = tools.context.repo.name;

--- a/index.js
+++ b/index.js
@@ -10,7 +10,6 @@ Toolkit.run(async tools => {
   // Assign owner and repo data to variables
   const owner = tools.context.repo.owner;
   const repo = tools.context.repo.repo;
-  // const repoSHA = tools.context.repo.sha;
 
   // Get Latest DEV Posts
 
@@ -21,6 +20,7 @@ Toolkit.run(async tools => {
   var devPostCoverImage; // Cover Image of most recent published DEV post
   var devPostURL; // URL to most recently published DEV post
   var numOfDevPosts; // Count of DEV posts
+  var repoSHA; // SHA of Master Branch in Repo
 
   // Create headers for DEV request
   var headers = {
@@ -123,10 +123,12 @@ Toolkit.run(async tools => {
       repo
     })).data;
 
-    console.log(`REFSDATA: ${JSON.stringify(refsData)}`);
-
     // If branch does not exist, create branch
     if (refsData.filter(data => (data.ref == 'refs/heads/dev_to_jekyll')).length == 0) {
+
+      // Get Master Branch SHA
+      refsFiltered = refsdata.filter(ref => ref.ref == 'refs/heads/master');
+      repoSHA = refsFiltered[0]["object"]["sha"];
 
       // Create a New Branch for the PR
       newBranch = (await tools.github.git.createRef({

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ const btoa = require('btoa');
 Toolkit.run(async tools => {
   console.log(tools.context)
   // Assign owner and repo data to variables
-  const owner = tools.context.github.repository.owner.login;
-  const repo = tools.context.github.repository.name;
-  const repoSHA = tools.context.github.repository.sha;
+  const owner = tools.github.repos.owner.login;
+  const repo = tools.github.repos.name;
+  const repoSHA = tools.github.repos.sha;
 
   // Get Latest DEV Posts
 

--- a/index.js
+++ b/index.js
@@ -5,8 +5,6 @@ const axios = require('axios').default;
 const btoa = require('btoa');
 
 Toolkit.run(async tools => {
-  console.log(tools.context);
-  console.log(`REPO: ${JSON.stringify(tools.context.repo)}`);
   // Assign owner and repo data to variables
   const owner = tools.context.repo.owner;
   const repo = tools.context.repo.repo;

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ const btoa = require('btoa');
 Toolkit.run(async tools => {
   console.log(tools.context)
   // Assign owner and repo data to variables
-  const owner = tools.github.repos.owner.login;
-  const repo = tools.github.repos.name;
-  const repoSHA = tools.github.repos.sha;
+  const owner = tools.context.repo.owner.login;
+  const repo = tools.context.repo.name;
+  const repoSHA = tools.context.repo.sha;
 
   // Get Latest DEV Posts
 

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ const btoa = require('btoa');
 Toolkit.run(async tools => {
   console.log(tools.context)
   // Assign owner and repo data to variables
-  const owner = tools.context.payload.repository.owner.login;
-  const repo = tools.context.payload.repository.name;
-  const repoSHA = tools.context.sha;
+  const owner = tools.context.github.repository.owner.login;
+  const repo = tools.context.github.repository.name;
+  const repoSHA = tools.context.github.repository.sha;
 
   // Get Latest DEV Posts
 

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const axios = require('axios').default;
 const btoa = require('btoa');
 
 Toolkit.run(async tools => {
+  console.log(tools.context)
   // Assign owner and repo data to variables
   const owner = tools.context.payload.repository.owner.login;
   const repo = tools.context.payload.repository.name;


### PR DESCRIPTION
Discovered that `tools.context` differs greatly if the context is a cron job, and the cron job `context` does not contain repository information. Therefore, refactored to get repository information regardless of what the `context` is.